### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,13 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "illuminate/database": ">= 5.5"
+        "illuminate/database": "5.5.*"
     },
     "autoload": {
         "psr-4": {
             "ResultSystems\\Relationships\\": "src/Relationships"
         }
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.

Also prefer-stable will ensure it downloads stable versions of your dependencies. 